### PR TITLE
[BUGFIX] Exit on error

### DIFF
--- a/main.go
+++ b/main.go
@@ -36,8 +36,8 @@ func main() {
 
 	flag.Parse()
 
-	if user == "" || token == "" || prefix == "" {
-		fmt.Println("Please specify jenkins user, token and prefix")
+	if user == "" || token == "" || prefix == "" || server == "" {
+		fmt.Println("Please specify jenkins user (-u), token (-t), server (-s) and prefix (-p)")
 		os.Exit(1)
 	}
 
@@ -51,7 +51,8 @@ func main() {
 
 	response, err := http.Get(fmt.Sprintf("https://%s:%s@%s/api/json", user, token, server))
 	if err != nil {
-		fmt.Println("Failed to download json from https://", server, "/api/json")
+		fmt.Printf("Failed to download json from https://%s/api/json\n", server)
+		os.Exit(1)
 	}
 	defer response.Body.Close()
 


### PR DESCRIPTION
When server variable is empty, there is no error message, even though the argument is required. Additionally when the Jenkins server can not be reached, there will be a segmentation violation as there is no exit, but just logging.

```
bin/jenkins-build-metrics -u testuser -t some-token -p "test.backend.jenkins" -s localhost
Failed to download json from https:// localhost /api/json
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x40 pc=0x120eb1f]

goroutine 1 [running]:
main.main()
	.../jenkins-build-metrics/main.go:56 +0x63f
```